### PR TITLE
VirtualHost, Exchanges and Queues enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,9 @@ target/
 profile_default/
 ipython_config.py
 
+# Jetbrains
+.idea/
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:

--- a/mcp_server_rabbitmq/admin.py
+++ b/mcp_server_rabbitmq/admin.py
@@ -26,9 +26,21 @@ class RabbitMQAdmin:
         response = self._make_request("GET", "queues")
         return response.json()
 
+    def list_queues_by_vhost(self, vhost: str = "/") -> List[Dict]:
+        """List all queues in the RabbitMQ server for a specific vhost"""
+        vhost_encoded = requests.utils.quote(vhost, safe="")
+        response = self._make_request("GET", f"queues/{vhost_encoded}")
+        return response.json()
+
     def list_exchanges(self) -> List[Dict]:
         """List all exchanges in the RabbitMQ server"""
         response = self._make_request("GET", "exchanges")
+        return response.json()
+
+    def list_exchanges_by_vhost(self, vhost: str = "/") -> List[Dict]:
+        """List all exchanges in the RabbitMQ server for a specific vhost"""
+        vhost_encoded = requests.utils.quote(vhost, safe="")
+        response = self._make_request("GET", f"exchanges/{vhost_encoded}")
         return response.json()
 
     def get_queue_info(self, queue: str, vhost: str = "/") -> Dict:

--- a/mcp_server_rabbitmq/admin.py
+++ b/mcp_server_rabbitmq/admin.py
@@ -84,4 +84,6 @@ class RabbitMQAdmin:
         return response.json()
 
     def list_vhosts(self) -> Dict:
-        raise NotImplementedError()
+        """List all vhost in the RabbitMQ server"""
+        response = self._make_request("GET", "vhosts")
+        return response.json()

--- a/mcp_server_rabbitmq/handlers.py
+++ b/mcp_server_rabbitmq/handlers.py
@@ -26,11 +26,18 @@ def handle_list_queues(rabbitmq_admin: RabbitMQAdmin) -> List[str]:
     result = rabbitmq_admin.list_queues()
     return [queue["name"] for queue in result]
 
+def handle_list_queues_by_vhost(rabbitmq_admin: RabbitMQAdmin, vhost: str = "/") -> List[str]:
+    result = rabbitmq_admin.list_queues_by_vhost(vhost)
+    return [queue["name"] for queue in result]
+
 
 def handle_list_exchanges(rabbitmq_admin: RabbitMQAdmin) -> List[str]:
     result = rabbitmq_admin.list_exchanges()
     return [exchange["name"] for exchange in result]
 
+def handle_list_exchanges_by_vhost(rabbitmq_admin: RabbitMQAdmin, vhost: str = "/") -> List[str]:
+    result = rabbitmq_admin.list_exchanges_by_vhost(vhost)
+    return [queue["name"] for queue in result]
 
 def handle_list_vhosts(rabbitmq_admin: RabbitMQAdmin) -> List[str]:
     result = rabbitmq_admin.list_vhosts()

--- a/mcp_server_rabbitmq/handlers.py
+++ b/mcp_server_rabbitmq/handlers.py
@@ -32,6 +32,11 @@ def handle_list_exchanges(rabbitmq_admin: RabbitMQAdmin) -> List[str]:
     return [exchange["name"] for exchange in result]
 
 
+def handle_list_vhosts(rabbitmq_admin: RabbitMQAdmin) -> List[str]:
+    result = rabbitmq_admin.list_vhosts()
+    return [vhost["name"] for vhost in result]
+
+
 def handle_get_queue_info(rabbitmq_admin: RabbitMQAdmin, queue: str, vhost: str = "/") -> dict:
     return rabbitmq_admin.get_queue_info(queue, vhost)
 

--- a/mcp_server_rabbitmq/server.py
+++ b/mcp_server_rabbitmq/server.py
@@ -19,6 +19,7 @@ from mcp_server_rabbitmq.handlers import (
     handle_list_exchanges,
     handle_list_queues,
     handle_purge_queue,
+    handle_list_vhosts
 )
 
 
@@ -128,6 +129,23 @@ class RabbitMQMCPServer:
             except Exception as e:
                 self.logger.error(f"{e}")
                 return f"Failed to list exchanges: {e}"
+
+        @self.mcp.tool()
+        def list_vhosts() -> str:
+            """List all the virtual hosts (vhosts) in the broker."""
+            try:
+                admin = RabbitMQAdmin(
+                    self.rabbitmq_host,
+                    self.rabbitmq_api_port,
+                    self.rabbitmq_username,
+                    self.rabbitmq_password,
+                    self.rabbitmq_use_tls,
+                )
+                result = handle_list_vhosts(admin)
+                return str(result)
+            except Exception as e:
+                self.logger.error(f"{e}")
+                return f"Failed to list virtual hosts: {e}"
 
         @self.mcp.tool()
         def get_queue_info(queue: str, vhost: str = "/") -> str:

--- a/mcp_server_rabbitmq/server.py
+++ b/mcp_server_rabbitmq/server.py
@@ -19,7 +19,9 @@ from mcp_server_rabbitmq.handlers import (
     handle_list_exchanges,
     handle_list_queues,
     handle_purge_queue,
-    handle_list_vhosts
+    handle_list_vhosts,
+    handle_list_queues_by_vhost,
+    handle_list_exchanges_by_vhost
 )
 
 
@@ -114,6 +116,23 @@ class RabbitMQMCPServer:
                 return f"Failed to list queues: {e}"
 
         @self.mcp.tool()
+        def list_queues_by_vhost(vhost: str = "/") -> str:
+            """List all the queues for a specific virtual host (vhost) in the broker."""
+            try:
+                admin = RabbitMQAdmin(
+                    self.rabbitmq_host,
+                    self.rabbitmq_api_port,
+                    self.rabbitmq_username,
+                    self.rabbitmq_password,
+                    self.rabbitmq_use_tls,
+                )
+                result = handle_list_queues_by_vhost(admin, vhost)
+                return str(result)
+            except Exception as e:
+                self.logger.error(f"{e}")
+                return f"Failed to get queue info: {e}"
+
+        @self.mcp.tool()
         def list_exchanges() -> str:
             """List all the exchanges in the broker."""
             try:
@@ -146,6 +165,23 @@ class RabbitMQMCPServer:
             except Exception as e:
                 self.logger.error(f"{e}")
                 return f"Failed to list virtual hosts: {e}"
+
+        @self.mcp.tool()
+        def list_exchanges_by_vhost(vhost: str = "/") -> str:
+            """List all the exchanges for a specific virtual host in the broker."""
+            try:
+                admin = RabbitMQAdmin(
+                    self.rabbitmq_host,
+                    self.rabbitmq_api_port,
+                    self.rabbitmq_username,
+                    self.rabbitmq_password,
+                    self.rabbitmq_use_tls,
+                )
+                result = handle_list_exchanges_by_vhost(admin, vhost)
+                return str(result)
+            except Exception as e:
+                self.logger.error(f"{e}")
+                return f"Failed to list exchanges: {e}"
 
         @self.mcp.tool()
         def get_queue_info(queue: str, vhost: str = "/") -> str:


### PR DESCRIPTION
I have implemented:
- An endpoint to be able to list all vhosts in a rabbitmq subscription
- Endpoints to filter queues or exchanges by selected virtual host to be more precise in the MCP response.